### PR TITLE
fix: resolve inboxMessages with empty inbox

### DIFF
--- a/ios/RNLeanplum.m
+++ b/ios/RNLeanplum.m
@@ -126,14 +126,8 @@
 
     RCT_REMAP_METHOD(inboxMessages,
                      fetchInboxMessagesWithResolver:(RCTPromiseResolveBlock)resolve
-                     rejecter:(RCTPromiseRejectBlock)reject)
-    {
-        if ([[Leanplum inbox] allMessages]) {
-            resolve([[Leanplum inbox] inbox_messages]);
-        } else {
-            NSError *error;
-            reject(@"no_messages", @"There were no messages", error);
-        }
+                     rejecter:(RCTPromiseRejectBlock)reject) {
+        return resolve([[Leanplum inbox] inbox_messages]);
     }
 
 @end


### PR DESCRIPTION
BREAKING CHANGE: inboxMessages will always resolve, regardless of whether or not the user has messages.

We shouldn’t reject the inboxMessages promise just because the inbox is empty. This change causes the inbox to always resolve even if the user doesn’t have any messages.