### PR TITLE
fix: remove commitlint/config-lerna-scopes

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,5 @@
 {
   "extends": [
-    "@commitlint/config-lerna-scopes",
     "@commitlint/config-conventional"
   ],
   "rules": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   },
   "description": "React Native bridge for Leanplum iOS and Android SDKs.",
   "devDependencies": {
-    "@commitlint/cli": "^7.0.0",
-    "@commitlint/config-conventional": "^7.0.1",
-    "@commitlint/config-lerna-scopes": "^7.0.0",
-    "@commitlint/travis-cli": "^7.0.0",
+    "@commitlint/cli": "^7.1.2",
+    "@commitlint/config-conventional": "^7.1.2",
+    "@commitlint/travis-cli": "^7.1.2",
     "@semantic-release/changelog": "^2.1.1",
     "@semantic-release/git": "^6.0.1",
     "@types/react-native": "^0.46.7",


### PR DESCRIPTION
This project doesn’t use Lerna so we don’t need to use `commitlint/config-lerna-scopes`