### PR TITLE
fix(react-native-leanplum): android build errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,8 +18,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.1'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Description:
When building android with react-native-leanplum-fcm, the following
error is thrown due to the build tools version

No resource found that matches the given name:
attr 'android:keyboardNavigationCluster'.
:@brandingbrand/react-native-leanplum:processReleaseResources FAILED