### PR TITLE
fix(android): guard against null json value

### DIFF
--- a/android/src/main/java/com/reactnativeleanplum/RNLPInbox.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLPInbox.java
@@ -111,6 +111,10 @@ public class RNLPInbox extends ReactContextBaseJavaModule {
     private static WritableMap jsonToReact(JSONObject data) throws JSONException {
         WritableMap map = new WritableNativeMap();
 
+        if (data == null) {
+            return map;
+        }
+        
         Iterator iterator = data.keys();
 
         while(iterator.hasNext()) {


### PR DESCRIPTION
Prevent jsonToReact() from attempting to iterate over a null value if JSON doesn't evaluate to an object.