### PR TITLE
chore: update android to sdk 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,16 +18,16 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.1'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.1'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86' ,'x86_64'
         }
     }
     lintOptions {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "@brandingbrand/react-native-leanplum",
+  "version": "3.0.0",
   "author": "Branding Brand LLC",
   "bugs": {
     "url": "https://github.com/brandingbrand/react-native-leanplum/issues"
@@ -20,7 +22,6 @@
   "homepage": "https://github.com/brandingbrand/react-native-leanplum#readme",
   "license": "MIT",
   "main": "dist/index.js",
-  "name": "@brandingbrand/react-native-leanplum",
   "peerDependencies": {
     "react-native": ">=0.40.0"
   },
@@ -34,7 +35,6 @@
     "test": "echo \"react-native-leanplum tests not yet implemented\""
   },
   "types": "./typings/index.d.ts",
-  "version": "2.0.3",
   "release": {
     "verifyConditions": [
       "@semantic-release/changelog",


### PR DESCRIPTION
BREAKING CHANGE: This updates the Android SDK to 28 and updates gradle settings to enable 64 bit releases.