### PR TITLE
New version of Android, fixed version of iOS and fixed issue with contexts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,9 @@ android {
 
 dependencies {
     compile "com.facebook.react:react-native:+"
-    compile 'com.leanplum:Leanplum:4.1.1'
+    compile 'com.leanplum:leanplum-fcm:5.2.3'
+    compile 'com.google.firebase:firebase-messaging:17.5.0'
+    
+    compile 'com.leanplum:leanplum-location:5.2.3'
+    compile "com.google.android.gms:play-services-location:17.0.0"
 }

--- a/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
@@ -20,15 +20,11 @@ import com.leanplum.LeanplumActivityHelper;
 import java.util.HashMap;
 
 public class RNLeanplum extends ReactContextBaseJavaModule {
-    private Application application;
-
     public RNLeanplum(ReactApplicationContext reactContext, Application app) {
         super(reactContext);
 
         Leanplum.setApplicationContext(app);
         LeanplumActivityHelper.enableLifecycleCallbacks(app);
-
-        application = app;
     }
 
     @Override
@@ -74,7 +70,7 @@ public class RNLeanplum extends ReactContextBaseJavaModule {
     
     @ReactMethod
     public void start(String userId, ReadableMap attributes, final Promise promise) {
-        Leanplum.start(application, userId, attributes != null ? attributes.toHashMap() : null, new StartCallback() {
+        Leanplum.start(getCurrentActivity(), userId, attributes != null ? attributes.toHashMap() : null, new StartCallback() {
             @Override
             public void onResponse(boolean success) {
                 promise.resolve(success);

--- a/react-native-leanplum.podspec
+++ b/react-native-leanplum.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Leanplum-iOS-SDK'
+  s.dependency 'Leanplum-iOS-SDK', '2.5.0'
 end

--- a/react-native-leanplum.podspec
+++ b/react-native-leanplum.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Leanplum-iOS-SDK', '2.5.0'
+  s.dependency 'Leanplum-iOS-SDK', '2.6.2'
 end


### PR DESCRIPTION
Hi,

I've been spending some time to integrate this library into our react-native project. I was facing a few issues that I managed to fix by patching your code with [patch-package](https://www.npmjs.com/package/patch-package).

Issue 1
iOS didn't use a fixed version number in the podspec, this would result in non reproducible builds for other developers/CI system (eg. when there is a newer version available).
This is fixed in this PR with a fixed version (3.0.0 might work as well, I didn't have time yet to test that)

Issue 2
On Android I was facing a few issues so I decided to move to the latest version (5.2.3) Good news is that your module layer is so thin, that this version was supported out of the box :-) One issue remained broken, on app start the connection to Leanplum was not set, I fixed this by giving the Activity to `Leanplum.start()` and not the application.

This PR is the bare minimum to fix the issues that I had, I might create another one in the future with version 3.0.0 in iOS and a bit of refactored Android code. I think we should be able to move out of the passing on of `Application` to all classes.

Let me know what you think of it