### PR TITLE
fix: Fix React Native Autolinking

### DIFF
--- a/android/src/main/java/com/reactnativeleanplum/RNLPInbox.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLPInbox.java
@@ -9,11 +9,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 
-import android.app.Application;
-
-import com.leanplum.ActionContext;
 import com.leanplum.Leanplum;
-import com.leanplum.LeanplumInbox;
 import com.leanplum.LeanplumInboxMessage;
 
 import java.util.Iterator;
@@ -27,7 +23,7 @@ public class RNLPInbox extends ReactContextBaseJavaModule {
     private static final String E_MESSAGE_NOT_FOUND_ERROR = "RNLPInboxMessageNotFound";
     private static final String E_MESSAGE_NOT_FOUND_REASON = "Could not find a message with the given id.";
 
-    public RNLPInbox(ReactApplicationContext reactContext, Application app) {
+    public RNLPInbox(ReactApplicationContext reactContext) {
         super(reactContext);
     }
 

--- a/android/src/main/java/com/reactnativeleanplum/RNLPInboxMessage.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLPInboxMessage.java
@@ -5,17 +5,14 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
-import android.app.Application;
-
 import com.leanplum.Leanplum;
-import com.leanplum.LeanplumInbox;
 import com.leanplum.LeanplumInboxMessage;
 
 public class RNLPInboxMessage extends ReactContextBaseJavaModule {
     private static final String E_MESSAGE_NOT_FOUND_ERROR = "RNLPInboxMessageNotFound";
     private static final String E_MESSAGE_NOT_FOUND_REASON = "Could not find a message with the given id.";
 
-    public RNLPInboxMessage(ReactApplicationContext reactContext, Application app) {
+    public RNLPInboxMessage(ReactApplicationContext reactContext) {
         super(reactContext);
     }
 

--- a/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
@@ -1,30 +1,25 @@
 package com.reactnativeleanplum;
 
-import android.app.Application;
+import android.app.Activity;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
-
-import com.leanplum.callbacks.StartCallback;
-import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.Leanplum;
 import com.leanplum.LeanplumActivityHelper;
+import com.leanplum.callbacks.StartCallback;
+import com.leanplum.callbacks.VariablesChangedCallback;
 
 import java.util.HashMap;
 
 public class RNLeanplum extends ReactContextBaseJavaModule {
-    public RNLeanplum(ReactApplicationContext reactContext, Application app) {
+    public RNLeanplum(ReactApplicationContext reactContext) {
         super(reactContext);
-
-        Leanplum.setApplicationContext(app);
-        LeanplumActivityHelper.enableLifecycleCallbacks(app);
     }
 
     @Override
@@ -70,7 +65,11 @@ public class RNLeanplum extends ReactContextBaseJavaModule {
     
     @ReactMethod
     public void start(String userId, ReadableMap attributes, final Promise promise) {
-        Leanplum.start(getCurrentActivity(), userId, attributes != null ? attributes.toHashMap() : null, new StartCallback() {
+        Activity currentActivity = getCurrentActivity();
+
+        Leanplum.setApplicationContext(currentActivity.getApplicationContext());
+        LeanplumActivityHelper.enableLifecycleCallbacks(currentActivity.getApplication());
+        Leanplum.start(currentActivity, userId, attributes != null ? attributes.toHashMap() : null, new StartCallback() {
             @Override
             public void onResponse(boolean success) {
                 promise.resolve(success);

--- a/android/src/main/java/com/reactnativeleanplum/RNLeanplumPackage.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLeanplumPackage.java
@@ -1,7 +1,5 @@
 package com.reactnativeleanplum;
 
-import android.app.Application;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -12,12 +10,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class RNLeanplumPackage implements ReactPackage {
-    private Application application;
-
-    public RNLeanplumPackage(Application app) {
-        application = app;
-    }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
@@ -27,9 +19,9 @@ public class RNLeanplumPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
-        modules.add(new RNLeanplum(reactContext, application));
-        modules.add(new RNLPInbox(reactContext, application));
-        modules.add(new RNLPInboxMessage(reactContext, application));
+        modules.add(new RNLeanplum(reactContext));
+        modules.add(new RNLPInbox(reactContext));
+        modules.add(new RNLPInboxMessage(reactContext));
 
         return modules;
     }


### PR DESCRIPTION
React Native's autolinking feature calls the package constructor with no parameters. This removes
the application dependency from the package/modules, so it should autolink correctly.