### PR TITLE
Safeguard currentActivity being null during start

### DIFF
--- a/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
@@ -67,8 +67,11 @@ public class RNLeanplum extends ReactContextBaseJavaModule {
     public void start(String userId, ReadableMap attributes, final Promise promise) {
         Activity currentActivity = getCurrentActivity();
 
-        Leanplum.setApplicationContext(currentActivity.getApplicationContext());
-        LeanplumActivityHelper.enableLifecycleCallbacks(currentActivity.getApplication());
+        if (currentActivity != null) {
+            Leanplum.setApplicationContext(currentActivity.getApplicationContext());
+            LeanplumActivityHelper.enableLifecycleCallbacks(currentActivity.getApplication());
+        }
+        
         Leanplum.start(currentActivity, userId, attributes != null ? attributes.toHashMap() : null, new StartCallback() {
             @Override
             public void onResponse(boolean success) {

--- a/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
+++ b/android/src/main/java/com/reactnativeleanplum/RNLeanplum.java
@@ -20,6 +20,12 @@ import java.util.HashMap;
 public class RNLeanplum extends ReactContextBaseJavaModule {
     public RNLeanplum(ReactApplicationContext reactContext) {
         super(reactContext);
+        Activity currentActivity = getCurrentActivity();
+
+        if (currentActivity != null) {
+            Leanplum.setApplicationContext(currentActivity.getApplicationContext());
+            LeanplumActivityHelper.enableLifecycleCallbacks(currentActivity.getApplication());
+        }
     }
 
     @Override
@@ -67,11 +73,6 @@ public class RNLeanplum extends ReactContextBaseJavaModule {
     public void start(String userId, ReadableMap attributes, final Promise promise) {
         Activity currentActivity = getCurrentActivity();
 
-        if (currentActivity != null) {
-            Leanplum.setApplicationContext(currentActivity.getApplicationContext());
-            LeanplumActivityHelper.enableLifecycleCallbacks(currentActivity.getApplication());
-        }
-        
         Leanplum.start(currentActivity, userId, attributes != null ? attributes.toHashMap() : null, new StartCallback() {
             @Override
             public void onResponse(boolean success) {


### PR DESCRIPTION
In some cases `start` call might be executed in the state when `getCurrentActivity()` returns null. In this case, the application crashes.

In the previous version of the library, the initialisation code were placed inside the constructor, but it was moved from there during refactoring to autolinking support.

I'm not 100% sure of what's the correct behaviour in cases when current activity is null and should we even call start or should we just return from this function, Leanplum documentation is a bit unclear here.

But at least by merging this PR we'll prevent `NullPointerException` crashes to happen.